### PR TITLE
Fix bug with bulk editing categories in WordPress 4.1.1+

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -308,6 +308,8 @@ function wp_media_categories_custom_bulk_action() {
 	$media_taxonomy         = sanitize_key( $_REQUEST[ 'bulk_tax_cat' ] );
 	$bulk_media_category_id = (int) $_REQUEST[ 'bulk_tax_id' ];
 
+	var_dump($_REQUEST);
+	
 	// Process all media_id s found in the request
 	foreach ( ( array ) $_REQUEST[ 'media' ] as $media_id ) {
 		$media_id = ( int ) $media_id;

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -308,9 +308,6 @@ function wp_media_categories_custom_bulk_action() {
 	$media_taxonomy         = sanitize_key( $_REQUEST[ 'bulk_tax_cat' ] );
 	$bulk_media_category_id = (int) $_REQUEST[ 'bulk_tax_id' ];
 
-	var_dump($_REQUEST);
-	die();
-	
 	// Process all media_id s found in the request
 	foreach ( ( array ) $_REQUEST[ 'media' ] as $media_id ) {
 		$media_id = ( int ) $media_id;

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -267,8 +267,8 @@ function wp_media_categories_custom_bulk_admin_footer() {
 			// add bulk_actions for each category term
 			foreach ( $media_terms as $term ) {
 				$optionTxt = esc_js( __( 'Toggle', 'wp-media-categories' ) . ' ' . $term->name );
-				$wp_media_categories_footer_script .= " jQuery('<option>').val('" . 'bulk_toggle' . "').attr('option_slug','" . $term->slug . "').text('" . $optionTxt . "').appendTo(\"select[name='action']\");";
-				$wp_media_categories_footer_script .= " jQuery('<option>').val('" . 'bulk_toggle' . "').attr('option_slug','" . $term->slug . "').text('" . $optionTxt . "').appendTo(\"select[name='action2']\");";
+				$wp_media_categories_footer_script .= " jQuery('<option>').val('" . 'bulk_toggle' . "').attr('option_slug','" . $term->term_id . "').text('" . $optionTxt . "').appendTo(\"select[name='action']\");";
+				$wp_media_categories_footer_script .= " jQuery('<option>').val('" . 'bulk_toggle' . "').attr('option_slug','" . $term->term_id . "').text('" . $optionTxt . "').appendTo(\"select[name='action2']\");";
 			}
 
 			$wp_media_categories_footer_script .= '});';

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -317,13 +317,6 @@ function wp_media_categories_custom_bulk_action() {
 			continue;
 		}
 
-		echo "hi";
-		var_dump(has_term( $bulk_media_category_id, $media_taxonomy, $media_id));
-		var_dump($bulk_media_category_id);
-		var_dump($media_taxonomy);
-		var_dump($media_id);
-		die();
-
 		// Set so remove the $bulk_media_category taxonomy from this media post
 		if ( has_term( $bulk_media_category_id, $media_taxonomy, $media_id ) ) {
 			$bulk_result = wp_remove_object_terms( $media_id, $bulk_media_category_id, $media_taxonomy );

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -309,6 +309,7 @@ function wp_media_categories_custom_bulk_action() {
 	$bulk_media_category_id = (int) $_REQUEST[ 'bulk_tax_id' ];
 
 	var_dump($_REQUEST);
+	die();
 	
 	// Process all media_id s found in the request
 	foreach ( ( array ) $_REQUEST[ 'media' ] as $media_id ) {

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -317,6 +317,13 @@ function wp_media_categories_custom_bulk_action() {
 			continue;
 		}
 
+		echo "hi";
+		var_dump(has_term( $bulk_media_category_id, $media_taxonomy, $media_id));
+		var_dump($bulk_media_category_id);
+		var_dump($media_taxonomy);
+		var_dump($media_id);
+		die();
+
 		// Set so remove the $bulk_media_category taxonomy from this media post
 		if ( has_term( $bulk_media_category_id, $media_taxonomy, $media_id ) ) {
 			$bulk_result = wp_remove_object_terms( $media_id, $bulk_media_category_id, $media_taxonomy );


### PR DESCRIPTION
Not sure exactly if this is when this bug was introduced, but several places in the code assume that option_slug is an integer, even though it's set as a slug.

Reverting it back to an integer made it work as intended.

Whether or not you were planning to switch to slug I'm not sure _shrug_

https://wordpress.org/support/topic/multi-select-bulk-action-not-working
