### PR TITLE
Fix bug with Wordpress 5.8 - media library grid mode infinite loading was replaced by button load

### DIFF
--- a/wp-media-categories/includes/ajax.php
+++ b/wp-media-categories/includes/ajax.php
@@ -180,6 +180,5 @@ function wp_media_categories_ajax_filter_query( $query ) {
 
         unset( $query[ $taxonomy ] );
     }
-    
     return $query;
 }

--- a/wp-media-categories/includes/ajax.php
+++ b/wp-media-categories/includes/ajax.php
@@ -134,3 +134,40 @@ function wp_media_categories_ajax_update_attachment_taxonomies() {
 
 	wp_send_json_success( $attachment );
 }
+
+function wp_media_categories_ajax_filter_query( $query ) {
+
+    // Get names of media taxonomies
+    $taxonomies = get_object_taxonomies( 'attachment', 'names' );
+
+    $query[ 'tax_query' ] = array( 'relation' => 'AND' );
+
+    foreach ( $taxonomies as $taxonomy ) {
+        if ( isset( $query[ $taxonomy ] ) ) {
+
+            // Filter a specific category
+            if ( is_numeric( $query[ $taxonomy ] ) ) {
+                array_push( $query[ 'tax_query' ], array(
+                    'taxonomy' => $taxonomy,
+                    'field' => 'id',
+                    'terms' => $query[ $taxonomy ]
+                ) );
+            }
+
+            // Filter No category
+            if ( $query[ $taxonomy ] == 'no_category' ) {
+                $all_terms_ids = wp_media_categories_get_terms_values( 'ids' );
+                array_push( $query[ 'tax_query' ], array(
+                    'taxonomy' => $taxonomy,
+                    'field' => 'id',
+                    'terms' => $all_terms_ids,
+                    'operator' => 'NOT IN',
+                ) );
+            }
+        }
+
+        unset( $query[ $taxonomy ] );
+    }
+    
+    return $query;
+}

--- a/wp-media-categories/includes/ajax.php
+++ b/wp-media-categories/includes/ajax.php
@@ -150,7 +150,9 @@ function wp_media_categories_ajax_filter_query( $query ) {
     // Get names of media taxonomies
     $taxonomies = get_object_taxonomies( 'attachment', 'names' );
 
-    $query[ 'tax_query' ] = array( 'relation' => 'AND' );
+    if ( ! isset( $query['tax_query'] ) ) {
+        $query['tax_query'] = array( 'relation' => 'AND' );
+    }
 
     foreach ( $taxonomies as $taxonomy ) {
         if ( isset( $query[ $taxonomy ] ) ) {

--- a/wp-media-categories/includes/ajax.php
+++ b/wp-media-categories/includes/ajax.php
@@ -167,7 +167,7 @@ function wp_media_categories_ajax_filter_query( $query ) {
             }
 
             // Filter No category
-            if ( $query[ $taxonomy ] == 'no_category' ) {
+            if ( $query[ $taxonomy ] === 'no_category' ) {
                 $all_terms_ids = wp_media_categories_get_terms_values( 'ids' );
                 array_push( $query[ 'tax_query' ], array(
                     'taxonomy' => $taxonomy,

--- a/wp-media-categories/includes/ajax.php
+++ b/wp-media-categories/includes/ajax.php
@@ -135,6 +135,16 @@ function wp_media_categories_ajax_update_attachment_taxonomies() {
 	wp_send_json_success( $attachment );
 }
 
+/**
+ * Filters the media query to include taxonomy queries for attachments.
+ *
+ * Adds tax_query arguments to the media query based on taxonomy filters provided.
+ *
+ * @since 1.0.2
+ *
+ * @param array $query The original media query arguments.
+ * @return array Modified media query arguments with taxonomy filters applied.
+ */
 function wp_media_categories_ajax_filter_query( $query ) {
 
     // Get names of media taxonomies

--- a/wp-media-categories/includes/ajax.php
+++ b/wp-media-categories/includes/ajax.php
@@ -148,37 +148,37 @@ function wp_media_categories_ajax_update_attachment_taxonomies() {
 function wp_media_categories_ajax_filter_query( $query ) {
 
     // Get names of media taxonomies
-    $taxonomies = get_object_taxonomies( 'attachment', 'names' );
+	// Get names of media taxonomies
+	$taxonomies = get_object_taxonomies( 'attachment', 'names' );
 
-    if ( ! isset( $query['tax_query'] ) ) {
-        $query['tax_query'] = array( 'relation' => 'AND' );
-    }
+	$query[ 'tax_query' ] = array( 'relation' => 'AND' );
 
-    foreach ( $taxonomies as $taxonomy ) {
-        if ( isset( $query[ $taxonomy ] ) ) {
+	foreach ( $taxonomies as $taxonomy ) {
+		if ( isset( $query[ $taxonomy ] ) ) {
 
-            // Filter a specific category
-            if ( is_numeric( $query[ $taxonomy ] ) ) {
-                array_push( $query[ 'tax_query' ], array(
-                    'taxonomy' => $taxonomy,
-                    'field' => 'id',
-                    'terms' => $query[ $taxonomy ]
-                ) );
-            }
+			// Filter a specific category
+			if ( is_numeric( $query[ $taxonomy ] ) ) {
+				array_push( $query[ 'tax_query' ], array(
+					'taxonomy' => $taxonomy,
+					'field' => 'id',
+					'terms' => $query[ $taxonomy ]
+				) );
+			}
 
-            // Filter No category
-            if ( $query[ $taxonomy ] === 'no_category' ) {
-                $all_terms_ids = wp_media_categories_get_terms_values( 'ids' );
-                array_push( $query[ 'tax_query' ], array(
-                    'taxonomy' => $taxonomy,
-                    'field' => 'id',
-                    'terms' => $all_terms_ids,
-                    'operator' => 'NOT IN',
-                ) );
-            }
-        }
+			// Filter No category
+			if ( $query[ $taxonomy ] == 'no_category' ) {
+				$all_terms_ids = wp_media_categories_get_terms_values( 'ids' );
+				array_push( $query[ 'tax_query' ], array(
+					'taxonomy' => $taxonomy,
+					'field' => 'id',
+					'terms' => $all_terms_ids,
+					'operator' => 'NOT IN',
+				) );
+			}
+		}
 
-        unset( $query[ $taxonomy ] );
-    }
-    return $query;
+		unset( $query[ $taxonomy ] );
+	}
+	
+	return $query;
 }

--- a/wp-media-categories/includes/hooks.php
+++ b/wp-media-categories/includes/hooks.php
@@ -29,7 +29,7 @@ add_filter( 'attachment_fields_to_edit', 'wp_media_attachment_fields', 10, 2 );
 // filter the attachments from user dropdown
 //add_action( 'wp_ajax_query-attachments', 'wp_media_categories_ajax_query_attachments', 0 );
 
-// filter the attachments from user dropdown by only filter query 
+// filter the attachments from user dropdown by only filtering query
 add_filter( 'ajax_query_attachments_args', 'wp_media_categories_ajax_filter_query' );
 
 // update the categories

--- a/wp-media-categories/includes/hooks.php
+++ b/wp-media-categories/includes/hooks.php
@@ -27,7 +27,10 @@ add_action( 'edit_attachment', 'wp_media_categories_set_attachment_category' );
 add_filter( 'attachment_fields_to_edit', 'wp_media_attachment_fields', 10, 2 );
 
 // filter the attachments from user dropdown
-add_action( 'wp_ajax_query-attachments', 'wp_media_categories_ajax_query_attachments', 0 );
+//add_action( 'wp_ajax_query-attachments', 'wp_media_categories_ajax_query_attachments', 0 );
+
+// filter the attachments from user dropdown by only filter query 
+add_filter( 'ajax_query_attachments_args', 'wp_media_categories_ajax_filter_query' );
 
 // update the categories
 add_action( 'wp_ajax_save-attachment-compat', 'wp_media_categories_ajax_update_attachment_taxonomies', 0 );


### PR DESCRIPTION
Hi, I think filtering query should be enough for using taxonomy in media grid.

The problem is with additional data, that original Wordpress ajax request return (version 5.8).

https://developer.wordpress.org/reference/functions/wp_ajax_query_attachments/
![image](https://user-images.githubusercontent.com/13632133/127736581-7445ea36-4720-4a07-88a9-4b4cfb2d5d0d.png)



